### PR TITLE
Add conditional iPad layout scaling

### DIFF
--- a/Froggy Hopper/GameScene.swift
+++ b/Froggy Hopper/GameScene.swift
@@ -7,6 +7,7 @@
 
 import SpriteKit
 import GameplayKit
+import UIKit
 
 class GameScene: SKScene, SKPhysicsContactDelegate {
     // Initialize the game elements
@@ -31,6 +32,14 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     var timerLabel: SKLabelNode!
     var isGameOver = false
     var backgroundMusicFiles: [String] = ["BackgroundMusic1.mp3", "BackgroundMusic2.mp3", "BackgroundMusic3.mp3", "BackgroundMusic4.mp3", "BackgroundMusic5.mp3", "BackgroundMusic6.mp3", "BackgroundMusic7.mp3", "BackgroundMusic8.mp3", "BackgroundMusic9.mp3", "BackgroundMusic10.mp3"]
+    private var isIPad: Bool {
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .pad
+        #else
+        return false
+        #endif
+    }
+    private var layoutScale: CGFloat { isIPad ? 1.35 : 1.0 }
 
     // Physics categories
     struct PhysicsCategory {
@@ -70,7 +79,14 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         background.anchorPoint = CGPoint(x: 0, y: 0)
         background.position = CGPoint(x: 0, y: 0)
         background.zPosition = -1
-        let scaleFactor = size.height / background.size.height
+        let scaleFactor: CGFloat
+        if isIPad {
+            let heightScale = size.height / background.size.height
+            let widthScale = size.width / background.size.width
+            scaleFactor = max(heightScale, widthScale)
+        } else {
+            scaleFactor = size.height / background.size.height
+        }
         background.xScale = scaleFactor
         background.yScale = scaleFactor
         addChild(background)
@@ -82,7 +98,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         frog = SKSpriteNode(imageNamed: "frog")
         frog.position = CGPoint(x: size.width / 2, y: size.height / 4)
         frog.zPosition = 1
-        frog.setScale(1.15)  // Set frog size
+        frog.setScale(1.15 * layoutScale)  // Set frog size
         
         // Calculate physics body size (70% of visual size)
         let frogRadius = min(frog.size.width, frog.size.height) * 0.35
@@ -110,27 +126,27 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         // Set up score label
         scoreLabel = SKLabelNode(fontNamed: "Chalkduster")
         scoreLabel.text = "Score: \(score)"
-        scoreLabel.fontSize = 28
+        scoreLabel.fontSize = 28 * layoutScale
         scoreLabel.fontColor = SKColor.red
-        scoreLabel.position = CGPoint(x: (size.width / 2) - 200, y: size.height - 110)
+        scoreLabel.position = CGPoint(x: (size.width / 2) - (isIPad ? 260 : 200), y: size.height - (isIPad ? 150 : 110))
         scoreLabel.zPosition = 2
         addChild(scoreLabel)
 
         // Set up timer label
         timerLabel = SKLabelNode(fontNamed: "Chalkduster")
         timerLabel.text = "Time: \(Int(gameTime))"
-        timerLabel.fontSize = 28
+        timerLabel.fontSize = 28 * layoutScale
         timerLabel.fontColor = SKColor.red
-        timerLabel.position = CGPoint(x: (size.width / 2 ) + 200, y: size.height - 110)
+        timerLabel.position = CGPoint(x: (size.width / 2 ) + (isIPad ? 260 : 200), y: size.height - (isIPad ? 150 : 110))
         timerLabel.zPosition = 2
         addChild(timerLabel)
 
         // Set up level label
         let levelLabel = SKLabelNode(fontNamed: "Chalkduster")
         levelLabel.text = "Level: \(level)"
-        levelLabel.fontSize = 36
+        levelLabel.fontSize = 36 * layoutScale
         levelLabel.fontColor = SKColor.red
-        levelLabel.position = CGPoint(x: size.width / 2, y: size.height - 110)
+        levelLabel.position = CGPoint(x: size.width / 2, y: size.height - (isIPad ? 150 : 110))
         levelLabel.zPosition = 2
         addChild(levelLabel)
 

--- a/Froggy Hopper/WelcomeScene.swift
+++ b/Froggy Hopper/WelcomeScene.swift
@@ -1,11 +1,20 @@
 import SpriteKit
+import UIKit
 
 public class WelcomeScene: SKScene {
-    
+
     // Track animation states
     private var isFrogJumping = false
     private var lastSpawnTime: TimeInterval = 0
-    
+    private var isIPad: Bool {
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .pad
+        #else
+        return false
+        #endif
+    }
+    private var layoutScale: CGFloat { isIPad ? 1.35 : 1.0 }
+
     public override func didMove(to view: SKView) {
         // Start background music
         SoundManager.shared.playBackgroundMusic(filename: "BackgroundMusic10.mp3")
@@ -42,16 +51,16 @@ public class WelcomeScene: SKScene {
         // Create lily pad platform
         let lilyPad = SKSpriteNode(imageNamed: "lily_pad")
         lilyPad.position = CGPoint(x: size.width/2, y: size.height * 0.4)
-        lilyPad.xScale = 1.5
-        lilyPad.yScale = 1.5
+        lilyPad.xScale = 1.5 * layoutScale
+        lilyPad.yScale = 1.5 * layoutScale
         lilyPad.zPosition = 1
         addChild(lilyPad)
-        
+
         // Add welcome frog
         let frog = SKSpriteNode(imageNamed: "frog")
         frog.position = CGPoint(x: size.width/2, y: size.height * 0.4 + 20)
-        frog.xScale = 1.3
-        frog.yScale = 1.3
+        frog.xScale = 1.3 * layoutScale
+        frog.yScale = 1.3 * layoutScale
         frog.zPosition = 2
         frog.name = "welcomeFrog"
         addChild(frog)
@@ -65,7 +74,7 @@ public class WelcomeScene: SKScene {
         // Add title
         let titleLabel = SKLabelNode(fontNamed: "Chalkduster")
         titleLabel.text = "Froggy Feed!"
-        titleLabel.fontSize = 41
+        titleLabel.fontSize = 41 * layoutScale
         titleLabel.fontColor = .white
         titleLabel.position = CGPoint(x: size.width/2, y: size.height * 0.7)
         titleLabel.zPosition = 2
@@ -74,7 +83,7 @@ public class WelcomeScene: SKScene {
         // Add subtitle with animation
         let subtitleLabel = SKLabelNode(fontNamed: "Chalkduster")
         subtitleLabel.text = "Eat bugs, get points!"
-        subtitleLabel.fontSize = 24
+        subtitleLabel.fontSize = 24 * layoutScale
         subtitleLabel.fontColor = .white
         subtitleLabel.position = CGPoint(x: size.width/2, y: size.height * 0.6)
         subtitleLabel.zPosition = 2
@@ -86,8 +95,8 @@ public class WelcomeScene: SKScene {
         subtitleLabel.run(fadeIn)
         
         // Create stylized start button
-        let buttonWidth: CGFloat = 240
-        let buttonHeight: CGFloat = 70
+        let buttonWidth: CGFloat = 240 * layoutScale
+        let buttonHeight: CGFloat = 70 * layoutScale
         
         // Create button shadow
         let buttonShadow = SKShapeNode(rectOf: CGSize(width: buttonWidth, height: buttonHeight), cornerRadius: 20)
@@ -114,10 +123,10 @@ public class WelcomeScene: SKScene {
         buttonBackground.addChild(innerGlow)
         
         addChild(buttonBackground)
-        
+
         let startLabel = SKLabelNode(fontNamed: "Chalkduster")
         startLabel.text = "Start Game"
-        startLabel.fontSize = 28
+        startLabel.fontSize = 28 * layoutScale
         startLabel.fontColor = SKColor(red: 0.1, green: 0.6, blue: 0.3, alpha: 1.0)
         startLabel.position = CGPoint(x: 0, y: -10)
         startLabel.zPosition = 3


### PR DESCRIPTION
## Summary
- add conditional compilation helpers to detect iPad builds and derive layout scaling
- scale welcome screen elements so visuals size appropriately on iPad
- adjust game scene background and HUD sizing/positioning to better fill iPad displays

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f34afc170833282a12352399ab756)