### PR TITLE
Add Game Center leaderboard support

### DIFF
--- a/Froggy Hopper.xcodeproj/project.pbxproj
+++ b/Froggy Hopper.xcodeproj/project.pbxproj
@@ -20,12 +20,13 @@
 		636008A929C60C2C00B83E75 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636008A829C60C2C00B83E75 /* AppDelegate.swift */; };
 		636008AB29C60C2C00B83E75 /* GameScene.sks in Resources */ = {isa = PBXBuildFile; fileRef = 636008AA29C60C2C00B83E75 /* GameScene.sks */; };
 		636008AD29C60C2C00B83E75 /* Actions.sks in Resources */ = {isa = PBXBuildFile; fileRef = 636008AC29C60C2C00B83E75 /* Actions.sks */; };
-		636008AF29C60C2C00B83E75 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636008AE29C60C2C00B83E75 /* GameScene.swift */; };
-		636008B129C60C2C00B83E75 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636008B029C60C2C00B83E75 /* GameViewController.swift */; };
-		636008B429C60C2C00B83E75 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 636008B229C60C2C00B83E75 /* Main.storyboard */; };
-		636008B629C60C3000B83E75 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 636008B529C60C3000B83E75 /* Assets.xcassets */; };
-		636008B929C60C3000B83E75 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 636008B729C60C3000B83E75 /* LaunchScreen.storyboard */; };
-		6365BD922A36A2D00049C64F /* SoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6365BD912A36A2D00049C64F /* SoundManager.swift */; };
+636008AF29C60C2C00B83E75 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636008AE29C60C2C00B83E75 /* GameScene.swift */; };
+636008B129C60C2C00B83E75 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636008B029C60C2C00B83E75 /* GameViewController.swift */; };
+636008B429C60C2C00B83E75 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 636008B229C60C2C00B83E75 /* Main.storyboard */; };
+636008B629C60C3000B83E75 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 636008B529C60C3000B83E75 /* Assets.xcassets */; };
+636008B929C60C3000B83E75 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 636008B729C60C3000B83E75 /* LaunchScreen.storyboard */; };
+25D750250988464FB74767EA /* GameCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C9DCB14CDB4150A454AA78 /* GameCenterManager.swift */; };
+6365BD922A36A2D00049C64F /* SoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6365BD912A36A2D00049C64F /* SoundManager.swift */; };
 		6365BD952A36AD470049C64F /* BackgroundMusic2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6365BD932A36AD460049C64F /* BackgroundMusic2.mp3 */; };
 		6365BD962A36AD470049C64F /* BackgroundMusic1.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6365BD942A36AD470049C64F /* BackgroundMusic1.mp3 */; };
 		6365BD9C2A36C0010049C64F /* BackgroundMusic5.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6365BD972A36BFFC0049C64F /* BackgroundMusic5.mp3 */; };
@@ -67,9 +68,10 @@
 		636008B029C60C2C00B83E75 /* GameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewController.swift; sourceTree = "<group>"; };
 		636008B329C60C2C00B83E75 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		636008B529C60C3000B83E75 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		636008B829C60C3000B83E75 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		6365BD912A36A2D00049C64F /* SoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManager.swift; sourceTree = "<group>"; };
-		6365BD932A36AD460049C64F /* BackgroundMusic2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = BackgroundMusic2.mp3; sourceTree = "<group>"; };
+636008B829C60C3000B83E75 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+6365BD912A36A2D00049C64F /* SoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManager.swift; sourceTree = "<group>"; };
+19C9DCB14CDB4150A454AA78 /* GameCenterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCenterManager.swift; sourceTree = "<group>"; };
+6365BD932A36AD460049C64F /* BackgroundMusic2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = BackgroundMusic2.mp3; sourceTree = "<group>"; };
 		6365BD942A36AD470049C64F /* BackgroundMusic1.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = BackgroundMusic1.mp3; sourceTree = "<group>"; };
 		6365BD972A36BFFC0049C64F /* BackgroundMusic5.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = BackgroundMusic5.mp3; sourceTree = "<group>"; };
 		6365BD982A36BFFD0049C64F /* BackgroundMusic3.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = BackgroundMusic3.mp3; sourceTree = "<group>"; };
@@ -141,11 +143,12 @@
 				636008AC29C60C2C00B83E75 /* Actions.sks */,
 				636008A829C60C2C00B83E75 /* AppDelegate.swift */,
 				63B2AAAC29C7A73400B58549 /* SceneDelegate.swift */,
-				636008AE29C60C2C00B83E75 /* GameScene.swift */,
-				588F50002D69B6B5006CA0F5 /* WelcomeScene.swift */,
-				636008B029C60C2C00B83E75 /* GameViewController.swift */,
-				6365BD912A36A2D00049C64F /* SoundManager.swift */,
-				6365BD942A36AD470049C64F /* BackgroundMusic1.mp3 */,
+636008AE29C60C2C00B83E75 /* GameScene.swift */,
+588F50002D69B6B5006CA0F5 /* WelcomeScene.swift */,
+636008B029C60C2C00B83E75 /* GameViewController.swift */,
+6365BD912A36A2D00049C64F /* SoundManager.swift */,
+19C9DCB14CDB4150A454AA78 /* GameCenterManager.swift */,
+6365BD942A36AD470049C64F /* BackgroundMusic1.mp3 */,
 				6365BD932A36AD460049C64F /* BackgroundMusic2.mp3 */,
 				6365BD982A36BFFD0049C64F /* BackgroundMusic3.mp3 */,
 				6365BD992A36BFFE0049C64F /* BackgroundMusic4.mp3 */,
@@ -298,12 +301,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				636008AF29C60C2C00B83E75 /* GameScene.swift in Sources */,
-				636008B129C60C2C00B83E75 /* GameViewController.swift in Sources */,
-				636008A929C60C2C00B83E75 /* AppDelegate.swift in Sources */,
-				588F50012D69B6B5006CA0F5 /* WelcomeScene.swift in Sources */,
-				63B2AAAD29C7A73400B58549 /* SceneDelegate.swift in Sources */,
-				6365BD922A36A2D00049C64F /* SoundManager.swift in Sources */,
-			);
+636008B129C60C2C00B83E75 /* GameViewController.swift in Sources */,
+636008A929C60C2C00B83E75 /* AppDelegate.swift in Sources */,
+588F50012D69B6B5006CA0F5 /* WelcomeScene.swift in Sources */,
+63B2AAAD29C7A73400B58549 /* SceneDelegate.swift in Sources */,
+25D750250988464FB74767EA /* GameCenterManager.swift in Sources */,
+6365BD922A36A2D00049C64F /* SoundManager.swift in Sources */,
+);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/Froggy Hopper/GameCenterManager.swift
+++ b/Froggy Hopper/GameCenterManager.swift
@@ -1,0 +1,96 @@
+import Foundation
+import GameKit
+import UIKit
+
+final class GameCenterManager: NSObject {
+    static let shared = GameCenterManager()
+
+    private let leaderboardIdentifier = "com.froggyhopper.highscores"
+
+    private override init() {
+        super.init()
+    }
+
+    func authenticateLocalPlayer(presentingViewController: UIViewController? = nil) {
+        let localPlayer = GKLocalPlayer.local
+
+        localPlayer.authenticateHandler = { [weak self] gcAuthVC, error in
+            if let authVC = gcAuthVC {
+                DispatchQueue.main.async {
+                    if let presenter = presentingViewController ?? self?.topViewController() {
+                        presenter.present(authVC, animated: true)
+                    }
+                }
+            } else if localPlayer.isAuthenticated {
+                print("Game Center authentication succeeded")
+            } else if let error = error {
+                print("Game Center authentication failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func report(score: Int, from viewController: UIViewController? = nil) {
+        let submitScore = {
+            let scoreReporter = GKScore(leaderboardIdentifier: self.leaderboardIdentifier)
+            scoreReporter.value = Int64(score)
+
+            GKScore.report([scoreReporter]) { error in
+                if let error = error {
+                    print("Failed to report Game Center score: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        if GKLocalPlayer.local.isAuthenticated {
+            submitScore()
+        } else {
+            authenticateLocalPlayer(presentingViewController: viewController)
+            if GKLocalPlayer.local.isAuthenticated {
+                submitScore()
+            }
+        }
+    }
+
+    func presentLeaderboard(from viewController: UIViewController) {
+        guard GKLocalPlayer.local.isAuthenticated else {
+            authenticateLocalPlayer(presentingViewController: viewController)
+            return
+        }
+
+        let leaderboardController = GKGameCenterViewController(leaderboardID: leaderboardIdentifier, playerScope: .global, timeScope: .allTime)
+        leaderboardController.gameCenterDelegate = self
+        leaderboardController.viewState = .leaderboards
+        viewController.present(leaderboardController, animated: true)
+    }
+
+    private func topViewController(base: UIViewController? = nil) -> UIViewController? {
+        let baseViewController = base ?? activeWindow()?.rootViewController
+
+        if let navigationController = baseViewController as? UINavigationController {
+            return topViewController(base: navigationController.visibleViewController)
+        }
+
+        if let tabBarController = baseViewController as? UITabBarController {
+            return topViewController(base: tabBarController.selectedViewController)
+        }
+
+        if let presented = baseViewController?.presentedViewController {
+            return topViewController(base: presented)
+        }
+
+        return baseViewController
+    }
+
+    private func activeWindow() -> UIWindow? {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}
+
+extension GameCenterManager: GKGameCenterControllerDelegate {
+    func gameCenterViewControllerDidFinish(_ gameCenterViewController: GKGameCenterViewController) {
+        gameCenterViewController.dismiss(animated: true)
+    }
+}

--- a/Froggy Hopper/GameScene.swift
+++ b/Froggy Hopper/GameScene.swift
@@ -190,6 +190,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         SoundManager.shared.stopBackgroundMusic()
         isGameOver = true
         gameTimer?.invalidate()
+        reportScoreToLeaderboard()
         let resultText = score >= 100 ? "Frog Won!" : "Try Again!"
         let nodeName = score >= 100 ? "nextLevelLabel" : "tryAgainLabel"
         // Create a yellow background for the text
@@ -225,6 +226,11 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             }
         }
         loadLevel()
+    }
+
+    private func reportScoreToLeaderboard() {
+        guard let viewController = view?.window?.rootViewController else { return }
+        GameCenterManager.shared.report(score: score, from: viewController)
     }
 
     func spawnFood() {

--- a/Froggy Hopper/GameViewController.swift
+++ b/Froggy Hopper/GameViewController.swift
@@ -13,6 +13,8 @@ class GameViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        GameCenterManager.shared.authenticateLocalPlayer(presentingViewController: self)
         
         guard let skView = view as? SKView else { return }
         

--- a/Froggy Hopper/WelcomeScene.swift
+++ b/Froggy Hopper/WelcomeScene.swift
@@ -132,6 +132,25 @@ public class WelcomeScene: SKScene {
         startLabel.zPosition = 3
         startLabel.name = "startButton"
         buttonBackground.addChild(startLabel)
+
+        // Create leaderboard button
+        let leaderboardButton = SKShapeNode(rectOf: CGSize(width: 200 * layoutScale, height: 60 * layoutScale), cornerRadius: 15)
+        leaderboardButton.fillColor = SKColor(red: 0.18, green: 0.65, blue: 0.38, alpha: 1.0)
+        leaderboardButton.strokeColor = SKColor(white: 1.0, alpha: 0.8)
+        leaderboardButton.lineWidth = 3
+        leaderboardButton.position = CGPoint(x: size.width / 2, y: size.height * 0.08)
+        leaderboardButton.zPosition = 2
+        leaderboardButton.name = "leaderboardButton"
+        addChild(leaderboardButton)
+
+        let leaderboardLabel = SKLabelNode(fontNamed: "Chalkduster")
+        leaderboardLabel.text = "Leaderboard"
+        leaderboardLabel.fontSize = 22 * layoutScale
+        leaderboardLabel.fontColor = .white
+        leaderboardLabel.position = CGPoint(x: 0, y: -8)
+        leaderboardLabel.zPosition = 3
+        leaderboardLabel.name = "leaderboardButton"
+        leaderboardButton.addChild(leaderboardLabel)
         
         // Add button animation
         let buttonScale = SKAction.sequence([
@@ -204,13 +223,27 @@ public class WelcomeScene: SKScene {
                 let scaleDown = SKAction.scale(to: 0.9, duration: 0.1)
                 let scaleUp = SKAction.scale(to: 1.0, duration: 0.1)
                 let sequence = SKAction.sequence([scaleDown, scaleUp])
-                
+
                 node.run(sequence) { [weak self] in
                     self?.startGame()
                 }
                 return
+            } else if node.name == "leaderboardButton" {
+                let scaleDown = SKAction.scale(to: 0.9, duration: 0.1)
+                let scaleUp = SKAction.scale(to: 1.0, duration: 0.1)
+                let sequence = SKAction.sequence([scaleDown, scaleUp])
+
+                node.run(sequence) { [weak self] in
+                    self?.showLeaderboard()
+                }
+                return
             }
         }
+    }
+
+    private func showLeaderboard() {
+        guard let viewController = view?.window?.rootViewController else { return }
+        GameCenterManager.shared.presentLeaderboard(from: viewController)
     }
     
     private func startGame() {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Froggy Hopper is a simple SpriteKit experiment that follows a hungry frog as it 
 - **Win condition**: Reach 100 points before the 120-second timer reaches zero.
 - **Try again**: If time runs out before hitting the target score, the scene resets and keeps you on the current level.
 
+## 🏅 Game Center leaderboard
+- The game now posts your final level score to the Game Center leaderboard with the identifier `com.froggyhopper.highscores`.
+- On the welcome screen, tap **Leaderboard** to open Apple's built-in Game Center UI and view global rankings.
+- To use the leaderboard in your own bundle ID, enable the Game Center capability for the **Froggy Hopper** target and create a matching leaderboard with the same identifier in App Store Connect.
+
 ## 🛠️ Project structure
 ```
 Froggy Hopper/


### PR DESCRIPTION
## Summary
- add a Game Center manager to authenticate players, submit scores, and present leaderboard UI
- authenticate on launch and submit final game scores to the configured leaderboard
- add a welcome screen button and documentation for the Game Center leaderboard identifier

## Testing
- Not run (Xcode/iOS simulator unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dc0a4db083328a722cb44d748138)